### PR TITLE
[#2] Add Navigation Between Android and IOS

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -34,6 +34,7 @@ android {
 
 dependencies {
     api(projects.shared.feature.contacts)
+    api(projects.shared.feature.contactdetails)
 
     implementation(libs.androidx.navigation.compose)
     testImplementation(libs.androidx.navigation.testing)

--- a/androidApp/src/main/java/com/blucky8649/brocallie/android/navigation/BroCallieNavHost.kt
+++ b/androidApp/src/main/java/com/blucky8649/brocallie/android/navigation/BroCallieNavHost.kt
@@ -1,12 +1,15 @@
 package com.blucky8649.brocallie.android.navigation
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.blucky8649.contacts.ROUTE_CONTACTS
-import com.blucky8649.contacts.contactsScreen
+import com.blucky8649.contacts.contactsRoute
+import com.blucky8649.contactdetails.ROUTE_CONTACT_DETAIL
+import com.blucky8649.contactdetails.contanctDetailRoute
 
 @Composable
 fun BroCallieNavHost(
@@ -18,6 +21,12 @@ fun BroCallieNavHost(
         navController = navController,
         startDestination = ROUTE_CONTACTS
     ) {
-        contactsScreen()
+        contactsRoute {
+            navController.navigate(ROUTE_CONTACT_DETAIL)
+        }
+        contanctDetailRoute(
+            onBackPressed = { navController.navigateUp() },
+            onSaveButtonClicked = { Log.d("DY_DEBUG", "onSaveButtonClicked") }
+        )
     }
 }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
+		94E084ABA23C55174B082E99 /* ContactScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E085DE71F23A756CAE804B /* ContactScreen.swift */; };
+		94E08CDA24714A01FF1527F8 /* ContactDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E0809CB3F14829F7168C41 /* ContactDetailScreen.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -33,6 +35,8 @@
 		7555FF7B242A565900829871 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		94E0809CB3F14829F7168C41 /* ContactDetailScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactDetailScreen.swift; sourceTree = "<group>"; };
+		94E085DE71F23A756CAE804B /* ContactScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactScreen.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,11 +78,12 @@
 		7555FF7D242A565900829871 /* iosApp */ = {
 			isa = PBXGroup;
 			children = (
-				058557BA273AAA24004C7B11 /* Assets.xcassets */,
 				7555FF82242A565900829871 /* ContentView.swift */,
+				058557BA273AAA24004C7B11 /* Assets.xcassets */,
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
+				94E08C7260F651DE6E2AB3B6 /* ui */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -88,6 +93,23 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		94E0845AC18DF9892E403F7C /* contact */ = {
+			isa = PBXGroup;
+			children = (
+				94E085DE71F23A756CAE804B /* ContactScreen.swift */,
+				94E0809CB3F14829F7168C41 /* ContactDetailScreen.swift */,
+			);
+			path = contact;
+			sourceTree = "<group>";
+		};
+		94E08C7260F651DE6E2AB3B6 /* ui */ = {
+			isa = PBXGroup;
+			children = (
+				94E0845AC18DF9892E403F7C /* contact */,
+			);
+			path = ui;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -184,6 +206,8 @@
 			files = (
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
+				94E084ABA23C55174B082E99 /* ContactScreen.swift in Sources */,
+				94E08CDA24714A01FF1527F8 /* ContactDetailScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,24 +1,40 @@
 import SwiftUI
 import shared
 
-struct ComposeView: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> some UIViewController {
-        ContactsScreen_iosKt.ContactsViewController()
-    }
-    
-    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
-}
-
 struct ContentView: View {
-    let greet = "Test Greet()!"
+    @State var showContactDetails: Bool = false
 
 	var body: some View {
-		ComposeView()
+        NavigationStack {
+            ContactScreen { name in
+                showContactDetails = true
+            }
+            .navigationDestination(isPresented: $showContactDetails) {
+                ContactDetailScreen(
+                    onBackPressed: { showContactDetails = false },
+                    onSaveButtonClicked: {}
+                )
+                .navigationBarBackButtonHidden(true)
+            }
+
+        }
 	}
 }
 
-struct ContentView_Previews: PreviewProvider {
-	static var previews: some View {
-		ContentView()
-	}
+#Preview {
+    ContentView()
+}
+
+/**
+ * Swipe - Back 강제 활성화
+ */
+extension UINavigationController: UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
 }

--- a/iosApp/iosApp/ui/contact/ContactDetailScreen.swift
+++ b/iosApp/iosApp/ui/contact/ContactDetailScreen.swift
@@ -1,0 +1,19 @@
+import Foundation
+import SwiftUI
+import shared
+
+struct ContactDetailScreen: UIViewControllerRepresentable {
+    let onBackPressed: () -> Void
+    let onSaveButtonClicked: () -> Void
+    
+    func makeUIViewController(context: Context) -> some UIViewController {
+        ContactDetailScreen_iosKt.ContactDetailViewController(
+            onBackPressed: onBackPressed,
+            onSaveButtonClicked: onSaveButtonClicked
+        )
+    
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+}
+

--- a/iosApp/iosApp/ui/contact/ContactScreen.swift
+++ b/iosApp/iosApp/ui/contact/ContactScreen.swift
@@ -1,0 +1,13 @@
+import Foundation
+import SwiftUI
+import shared
+
+struct ContactScreen: UIViewControllerRepresentable {
+    let onContactClick: (String) -> Void
+    
+    func makeUIViewController(context: Context) -> some UIViewController {
+        ContactsScreen_iosKt.ContactsViewController(onContactClick: onContactClick)
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,5 +19,7 @@ rootProject.name = "BroCallie"
 include(":androidApp")
 
 include(":shared:feature:contacts")
+include(":shared:feature:contactdetails")
+
 include(":shared:core:generative-ai")
 include(":shared:core:tts")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
             baseName = "shared"
             isStatic = true
             export(projects.shared.feature.contacts)
+            export(projects.shared.feature.contactdetails)
         }
     }
 
@@ -22,6 +23,7 @@ kotlin {
         commonMain.dependencies {
             //put your multiplatform dependencies here
             api(projects.shared.feature.contacts)
+            api(projects.shared.feature.contactdetails)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/shared/feature/contactdetails/build.gradle.kts
+++ b/shared/feature/contactdetails/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    alias(libs.plugins.brocallie.kotlin.multiplatform.shared)
+    alias(libs.plugins.brocallie.compose.multiplatform.shared)
+}

--- a/shared/feature/contactdetails/src/androidMain/kotlin/com/blucky8649/contactdetails/ContactDetailScreen.android.kt
+++ b/shared/feature/contactdetails/src/androidMain/kotlin/com/blucky8649/contactdetails/ContactDetailScreen.android.kt
@@ -1,0 +1,19 @@
+package com.blucky8649.contactdetails
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+
+const val ROUTE_CONTACT_DETAIL = "route_contact_detail"
+
+fun NavGraphBuilder.contanctDetailRoute(
+    onBackPressed: () -> Unit,
+    onSaveButtonClicked: () -> Unit
+) {
+    composable(route = ROUTE_CONTACT_DETAIL) {
+        ContactDetailScreen(
+            onBackPressed = onBackPressed,
+            onSaveButtonClicked = onSaveButtonClicked
+        )
+    }
+}
+

--- a/shared/feature/contactdetails/src/commonMain/kotlin/com/blucky8649/contactdetails/ContactDetailScreen.kt
+++ b/shared/feature/contactdetails/src/commonMain/kotlin/com/blucky8649/contactdetails/ContactDetailScreen.kt
@@ -1,0 +1,94 @@
+package com.blucky8649.contactdetails
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContactDetailScreen(
+    onBackPressed: () -> Unit,
+    onSaveButtonClicked: () -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var nickname by remember { mutableStateOf("") }
+    var contact by remember { mutableStateOf("") }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Contact Details") },
+                navigationIcon = {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                        contentDescription = null,
+                        modifier = Modifier.clickable { onBackPressed() }
+                    )
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .padding(16.dp)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = nickname,
+                onValueChange = { nickname = it },
+                label = { Text("Nickname") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = contact,
+                onValueChange = { contact = it },
+                label = { Text("Contact") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Button(
+                onClick = onSaveButtonClicked,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            ) {
+                Text("Save")
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+fun ContactDetailPreview() {
+    ContactDetailScreen(
+        onBackPressed = {},
+        onSaveButtonClicked = {}
+    )
+}

--- a/shared/feature/contactdetails/src/iosMain/kotlin/com/blucky8649/contactdetails/ContactDetailScreen.ios.kt
+++ b/shared/feature/contactdetails/src/iosMain/kotlin/com/blucky8649/contactdetails/ContactDetailScreen.ios.kt
@@ -1,0 +1,13 @@
+package com.blucky8649.contactdetails
+
+import androidx.compose.ui.window.ComposeUIViewController
+
+fun ContactDetailViewController(
+    onBackPressed: () -> Unit,
+    onSaveButtonClicked: () -> Unit
+) = ComposeUIViewController {
+    ContactDetailScreen(
+        onBackPressed = onBackPressed,
+        onSaveButtonClicked = onSaveButtonClicked
+    )
+}

--- a/shared/feature/contacts/src/androidMain/kotlin/com/blucky8649/contacts/ContactsScreen.android.kt
+++ b/shared/feature/contacts/src/androidMain/kotlin/com/blucky8649/contacts/ContactsScreen.android.kt
@@ -5,8 +5,10 @@ import androidx.navigation.compose.composable
 
 const val ROUTE_CONTACTS = "contacts"
 
-fun NavGraphBuilder.contactsScreen() {
+fun NavGraphBuilder.contactsRoute(
+    onContactClick: (String) -> Unit
+) {
     composable(route = ROUTE_CONTACTS) {
-        ContactsScreen()
+        ContactsScreen(onContactClick = onContactClick)
     }
 }

--- a/shared/feature/contacts/src/commonMain/kotlin/com/blucky8649/contacts/ContactsScreen.kt
+++ b/shared/feature/contacts/src/commonMain/kotlin/com/blucky8649/contacts/ContactsScreen.kt
@@ -10,7 +10,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 @Composable
 fun ContactsScreen(
     modifier: Modifier = Modifier,
-    viewModel: ContactViewModel = viewModel { ContactViewModel() }
+    viewModel: ContactViewModel = viewModel { ContactViewModel() },
+    onContactClick: (String) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
@@ -21,6 +22,7 @@ fun ContactsScreen(
     ) {
         items(uiState.contacts) {
             ContactItem(name = it.name) {
+                onContactClick(it)
                 println("click $it")
             }
         }

--- a/shared/feature/contacts/src/iosMain/kotlin/com/blucky8649/contacts/ContactsScreen.ios.kt
+++ b/shared/feature/contacts/src/iosMain/kotlin/com/blucky8649/contacts/ContactsScreen.ios.kt
@@ -2,6 +2,6 @@ package com.blucky8649.contacts
 
 import androidx.compose.ui.window.ComposeUIViewController
 
-fun ContactsViewController() = ComposeUIViewController {
-    ContactsScreen()
+fun ContactsViewController(onContactClick: (String) -> Unit) = ComposeUIViewController {
+    ContactsScreen(onContactClick = onContactClick)
 }


### PR DESCRIPTION
[#2] Add Navigation Between Android and IOS

### Android 
> Use Jetpack Navigation Component
```kotlin
@Composable
fun BroCallieNavHost(
    modifier: Modifier = Modifier,
    navController: NavHostController = rememberNavController()
) {
    NavHost(
        modifier = modifier,
        navController = navController,
        startDestination = ROUTE_CONTACTS
    ) {
        contactsRoute {
            navController.navigate(ROUTE_CONTACT_DETAIL)
        }
        contanctDetailRoute(
            onBackPressed = { navController.navigateUp() },
            onSaveButtonClicked = { Log.d("DY_DEBUG", "onSaveButtonClicked") }
        )
    }
}
```

### iOS
> Use Navigation Stack in SwiftUI
```swift
struct ContentView: View {
    @State var showContactDetails: Bool = false

    var body: some View {
        NavigationStack {
            ContactScreen { name in
                    showContactDetails = true
            }
            .navigationDestination(isPresented: $showContactDetails) {
                ContactDetailScreen(
                    onBackPressed: { showContactDetails = false },
                    onSaveButtonClicked: {}
                )
                .navigationBarBackButtonHidden(true)
            }
        }
    }
}
```